### PR TITLE
Allow to specify language when calling stop words function

### DIFF
--- a/cucco/cucco.py
+++ b/cucco/cucco.py
@@ -27,14 +27,14 @@ class Cucco(object):
             self,
             config=None,
             lazy_load=False):
-        self.__config = config if config else Config()
+        self._config = config if config else Config()
 
-        self.__characters_regexes = dict()
-        self.__logger = self.__config.logger
+        self._characters_regexes = dict()
+        self._logger = self._config.logger
         self.__stop_words = dict()
 
         # Load stop words
-        self._load_stop_words(self.__config.language if lazy_load else None)
+        self._load_stop_words(self._config.language if lazy_load else None)
 
     def _load_stop_words(self, language=None):
         """Load stop words into __stop_words set.
@@ -44,8 +44,11 @@ class Cucco(object):
 
         Args:
             language: Language code.
+
+        Returns:
+            A boolean indicating if the file was loaded.
         """
-        self.__logger.debug('Loading stop words')
+        self._logger.debug('Loading stop words')
 
         loaded = False
 
@@ -88,12 +91,15 @@ class Cucco(object):
 
         Args:
             path: Path to the stop words file.
+
+        Returns:
+            A boolean indicating if the file was loaded.
         """
         language = None
         loaded = False
 
         if os.path.isfile(path):
-            self.__logger.debug('Loading stop words in %s', path)
+            self._logger.debug('Loading stop words in %s', path)
 
             language = path.split('-')[-1]
 
@@ -121,7 +127,7 @@ class Cucco(object):
             The text normalized.
         """
         for normalization, kwargs in self._parse_normalizations(
-                normalizations or self.__config.normalizations):
+                normalizations or self._config.normalizations):
             text = getattr(self, normalization)(text, **kwargs)
 
         return text
@@ -174,16 +180,17 @@ class Cucco(object):
         Args:
             text: The text to be processed.
             ignore_case: Whether or not ignore case.
+            language: Code of the language to use.
 
         Returns:
             The text without stop words.
         """
         if not language:
-            language = self.__config.language
+            language = self._config.language
 
         if language not in self.__stop_words:
             if not self._load_stop_words(language):
-                self.__logger.error('No stop words file for the given language')
+                self._logger.error('No stop words file for the given language')
                 return text
 
         return ' '.join(word for word in text.split(' ') if (
@@ -207,11 +214,11 @@ class Cucco(object):
             return text
 
         characters = ''.join(sorted(characters))
-        if characters in self.__characters_regexes:
-            characters_regex = self.__characters_regexes[characters]
+        if characters in self._characters_regexes:
+            characters_regex = self._characters_regexes[characters]
         else:
             characters_regex = re.compile("[%s]" % re.escape(characters))
-            self.__characters_regexes[characters] = characters_regex
+            self._characters_regexes[characters] = characters_regex
 
         return characters_regex.sub(replacement, text)
 

--- a/tests/test_cucco.py
+++ b/tests/test_cucco.py
@@ -43,9 +43,22 @@ class TestCucco(object):
         for after, before, _, kwargs, message in self._tests_generator(request.node.name):
             assert self._cucco.remove_stop_words(before, **kwargs) == after, message
 
+        # Force language
+        self._cucco = Cucco()
+        for after, before, _, kwargs, message in self._tests_generator(request.node.name):
+            kwargs['language'] = 'en'
+            assert self._cucco.remove_stop_words(before, **kwargs) == after, message
+
+        # Force invalid language
+        self._cucco = Cucco()
+        for after, before, _, kwargs, message in self._tests_generator(request.node.name):
+            kwargs['language'] = 'invalid'
+            assert self._cucco.remove_stop_words(before, **kwargs) == before, message
+
         # Test lazy load
         self._cucco = Cucco(lazy_load=True)
         for after, before, _, kwargs, message in self._tests_generator(request.node.name):
+            kwargs['language'] = 'en'
             assert self._cucco.remove_stop_words(before, **kwargs) == after, message
 
     def test_replace_characters(self, request):


### PR DESCRIPTION
This is a required step to prepare the library to be used by the API. The behaviour of lazy_load is different now. If True, only the language defined in the configuration will be loaded. Otherwise, all languages will be loaded into memory. Closes #39